### PR TITLE
fix(Tas-135): Generate ids in server

### DIFF
--- a/how2meet/db/models.py
+++ b/how2meet/db/models.py
@@ -40,7 +40,7 @@ class Event(Base):
 class Guest(Base):
     __tablename__ = "guests"
 
-    id = Column(Uuid, primary_key=True, index=True)
+    id = Column(Uuid, primary_key=True, index=True, default=uuid4)
     name = Column(String(100))
     email = Column(String(100), nullable=True)
     phone = Column(String(15), nullable=True)

--- a/how2meet/db/schemas.py
+++ b/how2meet/db/schemas.py
@@ -73,10 +73,13 @@ class Guest(BaseModel):
 
 
 class GuestCreate(Guest):
-    pass
+    id: Optional[uuid.UUID] = Field(default=None, description="The event ID of the guest")
+    status: Optional[str] = Field(default='Pending', description="The status of the guest")
+    event_id: Optional[uuid.UUID] = Field(default=None, description="The event ID of the guest")
 
 
 class GuestUpdate(Guest):
+    id: Optional[uuid.UUID] = Field(default=None, description="The event ID of the guest")
     name: Optional[str] = Field(default=None, description="The name of the guest")
     status: Optional[str] = Field(default=None, description="The status of the guest")
     event_id: Optional[uuid.UUID] = Field(default=None, description="The event ID of the guest")

--- a/how2meet/db/schemas.py
+++ b/how2meet/db/schemas.py
@@ -65,6 +65,7 @@ class Guest(BaseModel):
     name: str
     email: Optional[str] = Field(default=None, description="The email of the guest")
     phone: Optional[str] = Field(default=None, description="The phone number of the guest")
+    # TODO: Make this an enum, default it to either "pending" or "invited" or something
     status: str
     event_id: uuid.UUID
 

--- a/how2meet/db/schemas.py
+++ b/how2meet/db/schemas.py
@@ -63,8 +63,8 @@ Guests schemas
 class Guest(BaseModel):
     id: uuid.UUID
     name: str
-    email: Optional[str] = Field(default="", description="The email of the guest")
-    phone: Optional[str] = Field(default="", description="The phone number of the guest")
+    email: Optional[str] = Field(default=None, description="The email of the guest")
+    phone: Optional[str] = Field(default=None, description="The phone number of the guest")
     status: str
     event_id: uuid.UUID
 

--- a/how2meet/db/schemas.py
+++ b/how2meet/db/schemas.py
@@ -75,7 +75,7 @@ class Guest(BaseModel):
 
 class GuestCreate(Guest):
     id: Optional[uuid.UUID] = Field(default=None, description="The event ID of the guest")
-    status: Optional[str] = Field(default='Pending', description="The status of the guest")
+    status: Optional[str] = Field(default="Pending", description="The status of the guest")
     event_id: Optional[uuid.UUID] = Field(default=None, description="The event ID of the guest")
 
 

--- a/how2meet/db/schemas.py
+++ b/how2meet/db/schemas.py
@@ -61,7 +61,7 @@ Guests schemas
 
 
 class Guest(BaseModel):
-    id: str
+    id: uuid.UUID
     name: str
     email: Optional[str] = Field(default="", description="The email of the guest")
     phone: Optional[str] = Field(default="", description="The phone number of the guest")


### PR DESCRIPTION
## Description
This PR fixes ID generation in the server, by adding uuid defaults in the models. It also fixes the `GuestCreate` and `GuestUpdate` schemas to correct field types/make them optional when necessary. 

## Testing
This PR was tested by exercising all of the Event and Guest API endpoints.
